### PR TITLE
Mixed join support

### DIFF
--- a/mindsdb_sql_parser/__about__.py
+++ b/mindsdb_sql_parser/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql_parser'
 __package_name__ = 'mindsdb_sql_parser'
-__version__ = '0.0.2'
+__version__ = '0.1.0'
 __description__ = "Mindsdb SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -1215,7 +1215,8 @@ class MindsDBParser(Parser):
                     condition=p.expr)
 
     @_('from_table_aliased COMMA from_table_aliased',
-       'join_tables_implicit COMMA from_table_aliased')
+       'join_tables_implicit COMMA from_table_aliased',
+       'join_tables COMMA from_table_aliased')
     def join_tables_implicit(self, p):
         return Join(left=p[0],
                     right=p[2],


### PR DESCRIPTION
Example:
```sql
     select * from table1 a
       inner join table2 b on a.x = b.y  and k = p,
     table3,
     table4
```
Also updated version to '0.1.0'