### PR TITLE
Window function: add frame options to to_tree

### DIFF
--- a/mindsdb_sql_parser/ast/select/operation.py
+++ b/mindsdb_sql_parser/ast/select/operation.py
@@ -123,11 +123,18 @@ class WindowFunction(ASTNode):
             alias_str = f'\n{ind1}alias=' + self.alias.to_string()
         else:
             alias_str = ''
+
+        if self.modifier is not None:
+            modifier_str = f'\n{ind1}modifier=' + self.modifier
+        else:
+            modifier_str = ''
+
         return f'{ind}WindowFunction(\n' \
                f'{ind1}function=\n{fnc_str}' \
                f'{partition_str}' \
                f'{order_str}' \
                f'{alias_str}' \
+               f'{modifier_str}' \
                f'\n{ind})'
 
     def to_string(self, *args, **kwargs):


### PR DESCRIPTION
If is required by sqlalchemy render tests, used by this PR: https://github.com/mindsdb/mindsdb/pull/10310 
