### PR TITLE
Fix is quoted

### DIFF
--- a/mindsdb_sql_parser/__about__.py
+++ b/mindsdb_sql_parser/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql_parser'
 __package_name__ = 'mindsdb_sql_parser'
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 __description__ = "Mindsdb SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -1731,6 +1731,7 @@ class MindsDBParser(Parser):
        'identifier DOT star')
     def identifier(self, p):
         node = p[0]
+        is_quoted = False
         if isinstance(p[2], Star):
             node.parts.append(p[2])
         elif isinstance(p[2], int):
@@ -1739,7 +1740,8 @@ class MindsDBParser(Parser):
             node.parts.append(p[2])
         else:
             node.parts += p[2].parts
-            node.is_quoted.append(p[2].is_quoted[0])
+            is_quoted = p[2].is_quoted[0]
+        node.is_quoted.append(is_quoted)
         return node
 
     @_('quote_string',

--- a/tests/test_base_sql/test_select_structure.py
+++ b/tests/test_base_sql/test_select_structure.py
@@ -1183,10 +1183,10 @@ class TestMindsdb:
         assert str(ast) == str(expected_ast)
 
     def test_double_quote_render_skip(self):
-        sql = 'select `KEY_ID` from `Table1` where `id`=2'
+        sql = 'select `KEY_ID`, `a`.* from `Table1` where `id`=2'
 
         expected_ast = Select(
-            targets=[Identifier('KEY_ID')],
+            targets=[Identifier('KEY_ID'), Identifier(parts=['a', Star()])],
             from_table=Identifier(parts=['Table1']),
             where=BinaryOperation(op='=', args=[
                 Identifier('id'), Constant(2)
@@ -1198,6 +1198,7 @@ class TestMindsdb:
 
         # check is quoted
         assert ast.targets[0].is_quoted == [True]
+        assert ast.targets[1].is_quoted == [True, False]
         assert ast.from_table.is_quoted == [True]
         assert ast.where.args[0].is_quoted == [True]
 


### PR DESCRIPTION
For the case 
```
`a`.*
```
 `is_quoted` used to be [True]. The correct is [True, False]