### PR TITLE
Support lateral join

### DIFF
--- a/mindsdb_sql_parser/__about__.py
+++ b/mindsdb_sql_parser/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql_parser'
 __package_name__ = 'mindsdb_sql_parser'
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 __description__ = "Mindsdb SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql_parser/lexer.py
+++ b/mindsdb_sql_parser/lexer.py
@@ -53,7 +53,7 @@ class MindsDBLexer(Lexer):
         GROUP_BY, HAVING, ORDER_BY,
         STAR, FOR, UPDATE,
 
-        JOIN, INNER, OUTER, CROSS, LEFT, RIGHT, ON, ASOF,
+        JOIN, INNER, OUTER, CROSS, LEFT, RIGHT, ON, ASOF, LATERAL,
 
         UNION, ALL, INTERSECT, EXCEPT,
 
@@ -236,6 +236,7 @@ class MindsDBLexer(Lexer):
     LEFT = r'\bLEFT\b'
     RIGHT = r'\bRIGHT\b'
     ASOF = r'\bASOF\b'
+    LATERAL = r'\bLATERAL\b'
 
     # UNION
 

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -1283,9 +1283,14 @@ class MindsDBParser(Parser):
        'OUTER JOIN',
        'LEFT OUTER JOIN',
        'FULL OUTER JOIN',
-       'ASOF JOIN',
-       'ASOF LEFT JOIN',
+       )
+    def join_type(self, p):
+        return ' '.join([x for x in p])
+
+    @_('join_type',
+       'ASOF join_type',
        'LEFT ASOF JOIN',
+       'join_type LATERAL',
        )
     def join_clause(self, p):
         return ' '.join([x for x in p])


### PR DESCRIPTION
Example query:
```sql
SELECT t.name AS name, t.driver AS driver, r.*
FROM tags t INNER JOIN LATERAL
	(SELECT longitude, latitude
	FROM readings r
	WHERE r.tags_id=t.id
	ORDER BY time DESC LIMIT 1)  r ON true
WHERE t.name IS NOT NULL
AND t.fleet = 'South'
```