### PR TITLE
Updated the Syntax for CREATE KNOWLEDGE_BASE

### DIFF
--- a/mindsdb_sql_parser/ast/mindsdb/knowledge_base.py
+++ b/mindsdb_sql_parser/ast/mindsdb/knowledge_base.py
@@ -66,10 +66,9 @@ class CreateKnowledgeBase(ASTNode):
         using_ar = []
         if self.storage:
             using_ar.append(f"  STORAGE={self.storage.to_string()}")
-        embedding_model_str = ""
-        if self.embedding_model_str:
+        if self.embedding_model:
             using_ar.append(f"  EMBEDDING_MODEL={json.dumps(self.embedding_model)}")
-        if self.reranking_model_str:
+        if self.reranking_model:
             using_ar.append(f"  RERANKING_MODEL={json.dumps(self.reranking_model)}")
 
         params = self.params.copy()

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -115,7 +115,7 @@ class MindsDBParser(Parser):
         model = params.pop('model', None)
         storage = params.pop('storage', None)
 
-        if isinstance(model, str):
+        if isinstance(storage, str):
             # convert to identifier
             storage = Identifier(storage)
 

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -112,22 +112,20 @@ class MindsDBParser(Parser):
         name = p.identifier
         # check model and storage are in params
         params = {k.lower(): v for k, v in params.items()}  # case insensitive
-        model = params.pop('model', None)
+        embedding_model = params.pop('embedding_model', None)
+        reranking_model = params.pop('reranking_model', None)
         storage = params.pop('storage', None)
 
         if isinstance(storage, str):
             # convert to identifier
             storage = Identifier(storage)
 
-        if isinstance(model, str):
-            # convert to identifier
-            model = Identifier(model)
-
         if_not_exists = p.if_not_exists_or_empty
 
         return CreateKnowledgeBase(
             name=name,
-            model=model,
+            embedding_model=embedding_model,
+            reranking_model=reranking_model,
             storage=storage,
             from_select=from_query,
             params=params,


### PR DESCRIPTION
This PR updates the syntax for `CREATE KNOWLEDGE_BASE` queries, specifically the parsing of parameters.

Fixes https://linear.app/mindsdb/issue/BE-869/update-the-syntax-for-create-knowledge-base-queries

The following syntax has now been supported:
```
query = parse_sql("""
    CREATE KNOWLEDGE BASE my_kb
    USING
        embedding_model = {
            "model": "gpt-4",
        	"provider_url": "openai",
            "api_key": "jhakhsuashd"
        },
        reranking_model = {
            "model": "gpt-4",
        	"provider_url": "openai",
            "api_key": "jhakhsuashd"
        },
        storage = chroma_dev_local.world_news_index
"""
)
```

<img width="1125" alt="Screenshot 2025-04-04 at 13 02 56" src="https://github.com/user-attachments/assets/333f2113-6537-49e0-a2e0-a3ec34f5a14e" />

I will work on the execution of the updated queries in MindsDB now.