### PR TITLE
Fixed system variable parsing

### DIFF
--- a/mindsdb_sql_parser/__about__.py
+++ b/mindsdb_sql_parser/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql_parser'
 __package_name__ = 'mindsdb_sql_parser'
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 __description__ = "Mindsdb SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql_parser/lexer.py
+++ b/mindsdb_sql_parser/lexer.py
@@ -350,7 +350,11 @@ class MindsDBLexer(Lexer):
     def ignore_newline(self, t):
         self.lineno += len(t.value)
 
-    @_(r'@(?:([a-zA-Z_$0-9]*[a-zA-Z_$]+[a-zA-Z_$0-9]*)|(?:`([^`]+)`))')
+    @_(r'@[a-zA-Z_.$]{1}[a-zA-Z_.$\d]+',
+       r"@'[a-zA-Z_.$]{1}[a-zA-Z_.$\d][^']*'",
+       r"@`[a-zA-Z_.$]{1}[a-zA-Z_.$\d][^`]*`",
+       r'@"[a-zA-Z_.$]{1}[a-zA-Z_.$\d][^"]*"'
+       )
     def VARIABLE(self, t):
         t.value = t.value.lstrip('@')
 
@@ -362,7 +366,11 @@ class MindsDBLexer(Lexer):
             t.value = t.value.strip('`')
         return t
 
-    @_(r'@@(?:([a-zA-Z_$0-9]*[a-zA-Z_$]+[a-zA-Z_$0-9]*)|(?:`([^`]+)`))')
+    @_(r'@@[a-zA-Z_.$]{1}[a-zA-Z_.$\d]+',
+       r"@@'[a-zA-Z_.$]{1}[a-zA-Z_.$\d][^']*'",
+       r"@@`[a-zA-Z_.$]{1}[a-zA-Z_.$\d][^`]*`",
+       r'@@"[a-zA-Z_.$]{1}[a-zA-Z_.$\d][^"]*"'
+       )
     def SYSTEM_VARIABLE(self, t):
         t.value = t.value.lstrip('@')
 

--- a/tests/test_mindsdb/test_variables.py
+++ b/tests/test_mindsdb/test_variables.py
@@ -37,3 +37,15 @@ class TestMDBParser:
         assert str(ast).lower() == sql.lower()
         assert str(ast) == str(expected_ast)
 
+    def test_mysql(self):
+        sql = 'select @@session.auto_increment_increment, @@character_set_client'
+        ast = parse_sql(sql)
+        expected_ast = Select(
+            targets=[
+                Variable('session.auto_increment_increment', is_system_var=True),
+                Variable('character_set_client', is_system_var=True),
+            ]
+        )
+
+        assert str(ast).lower() == sql.lower()
+        assert str(ast) == str(expected_ast)


### PR DESCRIPTION
Fix parsing error when system variable has two parts:
```sql
select @@session.auto_increment_increment
```
