### PR TITLE
Added the Syntax for UPDATE DATABASE

### DIFF
--- a/mindsdb_sql_parser/ast/mindsdb/__init__.py
+++ b/mindsdb_sql_parser/ast/mindsdb/__init__.py
@@ -1,6 +1,7 @@
 from .agents import CreateAgent, DropAgent, UpdateAgent
 from .create_view import CreateView
 from .create_database import CreateDatabase
+from .update_database import UpdateDatabase
 from .create_predictor import CreatePredictor, CreateAnomalyDetectionModel
 from .drop_predictor import DropPredictor
 from .retrain_predictor import RetrainPredictor

--- a/mindsdb_sql_parser/ast/mindsdb/update_database.py
+++ b/mindsdb_sql_parser/ast/mindsdb/update_database.py
@@ -1,0 +1,25 @@
+from mindsdb_sql_parser.ast.base import ASTNode
+from mindsdb_sql_parser.utils import indent
+
+
+class UpdateDatabase(ASTNode):
+    def __init__(self, name, updated_params, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = name
+        self.params = updated_params
+
+    def to_tree(self, *args, level=0, **kwargs):
+        ind = indent(level)
+        out_str = f'{ind}UpdateDatabase(' \
+                  f'name={self.name.to_string()}, ' \
+                  f'updated_params={self.params})'
+        return out_str
+
+    def get_string(self, *args, **kwargs):
+        params = self.params.copy()
+
+        set_ar = [f'{k}={repr(v)}' for k, v in params.items()]
+        set_str = ', '.join(set_ar)
+
+        out_str = f'UPDATE DATABASE {self.name.to_string()} SET {set_str}'
+        return out_str

--- a/mindsdb_sql_parser/ast/mindsdb/update_database.py
+++ b/mindsdb_sql_parser/ast/mindsdb/update_database.py
@@ -1,9 +1,18 @@
 from mindsdb_sql_parser.ast.base import ASTNode
+from mindsdb_sql_parser.ast.select import Identifier
 from mindsdb_sql_parser.utils import indent
 
 
 class UpdateDatabase(ASTNode):
-    def __init__(self, name, updated_params, *args, **kwargs):
+    """
+    Update a database.
+    """
+    def __init__(self, name: Identifier, updated_params: dict, *args, **kwargs):
+        """
+        Args:
+            name: Identifier -- name of the database to update.
+            params: dict -- parameters to update in the database.
+        """
         super().__init__(*args, **kwargs)
         self.name = name
         self.params = updated_params

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -78,6 +78,7 @@ class MindsDBParser(Parser):
        'delete',
        'evaluate',
        'drop_database',
+       'update_database',
        'drop_view',
        'drop_table',
        'create_table',

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -19,6 +19,7 @@ from mindsdb_sql_parser.ast.mindsdb.evaluate import Evaluate
 from mindsdb_sql_parser.ast.mindsdb.knowledge_base import CreateKnowledgeBase, DropKnowledgeBase, \
     CreateKnowledgeBaseIndex, DropKnowledgeBaseIndex
 from mindsdb_sql_parser.ast.mindsdb.skills import CreateSkill, DropSkill, UpdateSkill
+from mindsdb_sql_parser.ast.mindsdb.update_database import UpdateDatabase
 from mindsdb_sql_parser.exceptions import ParsingException
 from mindsdb_sql_parser.ast.mindsdb.retrain_predictor import RetrainPredictor
 from mindsdb_sql_parser.ast.mindsdb.finetune_predictor import FinetunePredictor
@@ -341,6 +342,11 @@ class MindsDBParser(Parser):
        'DROP SCHEMA if_exists_or_empty identifier')
     def drop_database(self, p):
         return DropDatabase(name=p.identifier, if_exists=p.if_exists_or_empty)
+
+    # UPDATE DATABASE
+    @_('UPDATE DATABASE identifier SET kw_parameter_list')
+    def update_database(self, p):
+        return UpdateDatabase(name=p.identifier, updated_params=p.kw_parameter_list)
 
     # Transactions
 

--- a/tests/test_mindsdb/test_databases.py
+++ b/tests/test_mindsdb/test_databases.py
@@ -6,7 +6,7 @@ from mindsdb_sql_parser.ast.mindsdb import *
 from mindsdb_sql_parser.lexer import MindsDBLexer
 
 
-class TestCreateDatabase:
+class TestDatabases:
     def test_create_database_lexer(self):
         sql = "CREATE DATABASE IF NOT EXISTS db WITH ENGINE = 'mysql', PARAMETERS = {\"user\": \"admin\", \"password\": \"admin\"}"
         tokens = list(MindsDBLexer().tokenize(sql))
@@ -130,3 +130,11 @@ class TestCreateDatabase:
         assert str(ast).lower() == str(expected_ast).lower()
         assert ast.to_tree() == expected_ast.to_tree()
 
+    def test_update_database(self):
+        sql = "UPDATE DATABASE db SET PARAMETERS = {'A': 1}"
+        ast = parse_sql(sql)
+
+        expected_ast = UpdateDatabase(name=Identifier('db'), updated_params={'PARAMETERS': {'A': 1}})
+
+        assert str(ast).lower() == str(expected_ast).lower()
+        assert ast.to_tree() == expected_ast.to_tree()


### PR DESCRIPTION
This PR adds the syntax for `UPDATE DATABASE`.

Fixes https://linear.app/mindsdb/issue/BE-1018/add-update-database-syntax-to-the-parser