### PR TITLE
Added the Syntax for ALTER VIEW

### DIFF
--- a/mindsdb_sql_parser/ast/mindsdb/__init__.py
+++ b/mindsdb_sql_parser/ast/mindsdb/__init__.py
@@ -1,5 +1,6 @@
 from .agents import CreateAgent, DropAgent, UpdateAgent
 from .create_view import CreateView
+from .alter_view import AlterView
 from .create_database import CreateDatabase
 from .create_predictor import CreatePredictor, CreateAnomalyDetectionModel
 from .drop_predictor import DropPredictor

--- a/mindsdb_sql_parser/ast/mindsdb/alter_view.py
+++ b/mindsdb_sql_parser/ast/mindsdb/alter_view.py
@@ -42,8 +42,8 @@ class AlterView(ASTNode):
         return out_str
     
     def get_string(self, *args, **kwargs):
-        from_str = f' FROM {str(self.from_table)} ' if self.from_table else ''
+        from_str = f' FROM {str(self.from_table)}' if self.from_table else ''
 
-        out_str = f'ALTER VIEW {self.name.to_string()} AS ( {self.query_str} ){from_str}'
+        out_str = f'ALTER VIEW {self.name.to_string()}{from_str} AS ( {self.query_str} )'
 
         return out_str

--- a/mindsdb_sql_parser/ast/mindsdb/alter_view.py
+++ b/mindsdb_sql_parser/ast/mindsdb/alter_view.py
@@ -1,0 +1,49 @@
+from mindsdb_sql_parser.ast.base import ASTNode
+from mindsdb_sql_parser.utils import indent
+from mindsdb_sql_parser.ast.select.identifier import Identifier
+
+
+class AlterView(ASTNode):
+    """
+    Alter a view.
+    """
+    def __init__(
+        self,
+        name: Identifier,
+        query_str: str,
+        from_table: Identifier = None,
+        *args, 
+        **kwargs
+    ):
+        """
+        Args:
+            name: Identifier -- name of the view to alter.
+            query_str: str -- the new query string for the view.
+            from_table: Identifier -- optional table to alter the view from.
+        """
+        super().__init__(*args, **kwargs)
+        self.name = name
+        self.query_str = query_str
+        self.from_table = from_table
+
+    def to_tree(self, *args, level=0, **kwargs):
+        ind = indent(level)
+        ind1 = indent(level+1)
+
+        name_str = f'\n{ind1}name={self.name.to_string()},'
+        from_table_str = f'\n{ind1}from_table=\n{self.from_table.to_tree(level=level+2)},' if self.from_table else ''
+        query_str = f'\n{ind1}query="{self.query_str}"'
+
+        out_str = f'{ind}AlterView(' \
+                  f'{name_str}' \
+                  f'{query_str}' \
+                  f'{from_table_str}' \
+                  f'\n{ind})'
+        return out_str
+    
+    def get_string(self, *args, **kwargs):
+        from_str = f' FROM {str(self.from_table)} ' if self.from_table else ''
+
+        out_str = f'ALTER VIEW {self.name.to_string()} AS ( {self.query_str} ){from_str}'
+
+        return out_str

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -693,8 +693,8 @@ class MindsDBParser(Parser):
                           if_not_exists=p.if_not_exists_or_empty)
 
     # ALTER VIEW
-    @_('ALTER VIEW identifier AS LPAREN raw_query RPAREN create_view_from_table_or_nothing',
-       'ALTER VIEW identifier LPAREN raw_query RPAREN create_view_from_table_or_nothing')
+    @_('ALTER VIEW identifier create_view_from_table_or_nothing AS LPAREN raw_query RPAREN',
+       'ALTER VIEW identifier create_view_from_table_or_nothing LPAREN raw_query RPAREN')
     def alter_view(self, p):
         query_str = tokens_to_string(p.raw_query)
 

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -10,6 +10,7 @@ from mindsdb_sql_parser.ast.mindsdb.create_predictor import CreatePredictor, Cre
 from mindsdb_sql_parser.ast.mindsdb.create_database import CreateDatabase
 from mindsdb_sql_parser.ast.mindsdb.create_ml_engine import CreateMLEngine
 from mindsdb_sql_parser.ast.mindsdb.create_view import CreateView
+from mindsdb_sql_parser.ast.mindsdb.alter_view import AlterView
 from mindsdb_sql_parser.ast.mindsdb.create_job import CreateJob
 from mindsdb_sql_parser.ast.mindsdb.chatbot import CreateChatBot, UpdateChatBot, DropChatBot
 from mindsdb_sql_parser.ast.mindsdb.drop_job import DropJob
@@ -78,6 +79,7 @@ class MindsDBParser(Parser):
        'evaluate',
        'drop_database',
        'drop_view',
+       'alter_view',
        'drop_table',
        'create_table',
        'create_job',
@@ -689,6 +691,18 @@ class MindsDBParser(Parser):
                           from_table=p.create_view_from_table_or_nothing,
                           query_str=query_str,
                           if_not_exists=p.if_not_exists_or_empty)
+
+    # ALTER VIEW
+    @_('ALTER VIEW identifier AS LPAREN raw_query RPAREN create_view_from_table_or_nothing',
+       'ALTER VIEW identifier LPAREN raw_query RPAREN create_view_from_table_or_nothing')
+    def alter_view(self, p):
+        query_str = tokens_to_string(p.raw_query)
+
+        return AlterView(
+            name=p.identifier,
+            from_table=p.create_view_from_table_or_nothing,
+            query_str=query_str
+        )
 
     @_('FROM identifier')
     def create_view_from_table_or_nothing(self, p):

--- a/tests/test_mindsdb/test_views.py
+++ b/tests/test_mindsdb/test_views.py
@@ -35,7 +35,7 @@ class TestViews:
         assert ast.to_tree() == expected_ast.to_tree()
 
     def test_alter_view_full(self):
-        sql = "ALTER VIEW my_view AS ( SELECT * FROM pred ) FROM integr"
+        sql = "ALTER VIEW my_view FROM integr AS ( SELECT * FROM pred )"
         ast = parse_sql(sql)
         expected_ast = AlterView(
             name=Identifier('my_view'),

--- a/tests/test_mindsdb/test_views.py
+++ b/tests/test_mindsdb/test_views.py
@@ -3,7 +3,7 @@ from mindsdb_sql_parser.ast.mindsdb import *
 from mindsdb_sql_parser.ast import *
 from mindsdb_sql_parser.lexer import MindsDBLexer
 
-class TestCreateView:
+class TestViews:
     def test_create_view_lexer(self):
         sql = "CREATE VIEW my_view FROM integration AS ( SELECT * FROM pred )"
         tokens = list(MindsDBLexer().tokenize(sql))
@@ -31,6 +31,27 @@ class TestCreateView:
         expected_ast = CreateView(name=Identifier('my_view'),
                                   query_str="SELECT * FROM pred")
 
+        assert str(ast) == str(expected_ast)
+        assert ast.to_tree() == expected_ast.to_tree()
+
+    def test_alter_view_full(self):
+        sql = "ALTER VIEW my_view AS ( SELECT * FROM pred ) FROM integr"
+        ast = parse_sql(sql)
+        expected_ast = AlterView(
+            name=Identifier('my_view'),
+            from_table=Identifier('integr'),
+            query_str="SELECT * FROM pred"
+        )
+        assert str(ast) == str(expected_ast)
+        assert ast.to_tree() == expected_ast.to_tree()
+
+    def test_alter_view_nofrom(self):
+        sql = "ALTER VIEW my_view AS ( SELECT * FROM pred )"
+        ast = parse_sql(sql)
+        expected_ast = AlterView(
+            name=Identifier('my_view'),
+            query_str="SELECT * FROM pred"
+        )
         assert str(ast) == str(expected_ast)
         assert ast.to_tree() == expected_ast.to_tree()
 


### PR DESCRIPTION
This PR adds the syntax for `ALTER VIEW`.

Fixes https://linear.app/mindsdb/issue/BE-1020/add-alter-view-syntax-to-the-parser