### PR TITLE
Support length in primary key type 

### DIFF
--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -723,6 +723,7 @@ class MindsDBParser(Parser):
     @_('id id',
        'id id DEFAULT id',
        'id id PRIMARY_KEY',
+       'id id LPAREN INTEGER RPAREN PRIMARY_KEY',
        'id id LPAREN INTEGER RPAREN',
        'id id LPAREN INTEGER COMMA INTEGER RPAREN',
        'id id LPAREN INTEGER RPAREN DEFAULT id',

--- a/tests/test_base_sql/test_create.py
+++ b/tests/test_base_sql/test_create.py
@@ -130,6 +130,26 @@ class TestCreateMindsdb:
         assert str(ast).lower() == str(expected_ast).lower()
         assert ast.to_tree() == expected_ast.to_tree()
 
+        sql = f'''
+         CREATE TABLE mydb.Persons(
+            Person varchar(10) PRIMARY KEY not null,
+            name TEXT NULL   
+         )
+        '''
+        ast = parse_sql(sql)
+
+        expected_ast = CreateTable(
+            name=Identifier('mydb.Persons'),
+            columns=[
+                TableColumn(name='Person', type='varchar', length=10, is_primary_key=True, nullable=False),
+                TableColumn(name='name', type='TEXT', nullable=True),
+            ]
+        )
+
+        assert str(ast).lower() == str(expected_ast).lower()
+        assert ast.to_tree() == expected_ast.to_tree()
+
+
         # multiple primary keys
 
         sql = f'''


### PR DESCRIPTION
Support length in primary key type 

```sql
CREATE TABLE  local_pg.use_cases (
    name                VARCHAR(255) PRIMARY KEY NOT NULL,  -- <--
    description         TEXT,
);
```