### PR TITLE
Added the Syntax for ALTER DATABASE

### DIFF
--- a/mindsdb_sql_parser/ast/mindsdb/__init__.py
+++ b/mindsdb_sql_parser/ast/mindsdb/__init__.py
@@ -1,4 +1,5 @@
 from .agents import CreateAgent, DropAgent, UpdateAgent
+from .alter_database import AlterDatabase
 from .create_view import CreateView
 from .create_database import CreateDatabase
 from .create_predictor import CreatePredictor, CreateAnomalyDetectionModel

--- a/mindsdb_sql_parser/ast/mindsdb/alter_database.py
+++ b/mindsdb_sql_parser/ast/mindsdb/alter_database.py
@@ -1,0 +1,34 @@
+from mindsdb_sql_parser.ast.base import ASTNode
+from mindsdb_sql_parser.ast.select import Identifier
+from mindsdb_sql_parser.utils import indent
+
+
+class AlterDatabase(ASTNode):
+    """
+    Alter a database.
+    """
+    def __init__(self, name: Identifier, altered_params: dict, *args, **kwargs):
+        """
+        Args:
+            name: Identifier -- name of the database to alter.
+            altered_params: dict -- parameters to alter in the database.
+        """
+        super().__init__(*args, **kwargs)
+        self.name = name
+        self.params = altered_params
+
+    def to_tree(self, *args, level=0, **kwargs):
+        ind = indent(level)
+        out_str = f'{ind}AlterDatabase(' \
+                  f'name={self.name.to_string()}, ' \
+                  f'altered_params={self.params})'
+        return out_str
+
+    def get_string(self, *args, **kwargs):
+        params = self.params.copy()
+
+        set_ar = [f'{k}={repr(v)}' for k, v in params.items()]
+        set_str = ', '.join(set_ar)
+
+        out_str = f'ALTER DATABASE {self.name.to_string()} {set_str}'
+        return out_str

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -78,6 +78,7 @@ class MindsDBParser(Parser):
        'delete',
        'evaluate',
        'drop_database',
+       'alter_database',
        'drop_view',
        'drop_table',
        'create_table',

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -350,7 +350,7 @@ class MindsDBParser(Parser):
        'DROP SCHEMA if_exists_or_empty identifier')
     def drop_database(self, p):
         return DropDatabase(name=p.identifier, if_exists=p.if_exists_or_empty)
-    
+
     # ALTER DATABASE
     @_('ALTER DATABASE identifier kw_parameter_list')
     def alter_database(self, p):

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -1,6 +1,7 @@
 from sly import Parser
 from mindsdb_sql_parser.ast import *
 from mindsdb_sql_parser.ast.drop import DropDatabase, DropView
+from mindsdb_sql_parser.ast.mindsdb.alter_database import AlterDatabase
 from mindsdb_sql_parser.ast.mindsdb.agents import CreateAgent, DropAgent, UpdateAgent
 from mindsdb_sql_parser.ast.mindsdb.drop_datasource import DropDatasource
 from mindsdb_sql_parser.ast.mindsdb.drop_predictor import DropPredictor
@@ -349,6 +350,15 @@ class MindsDBParser(Parser):
        'DROP SCHEMA if_exists_or_empty identifier')
     def drop_database(self, p):
         return DropDatabase(name=p.identifier, if_exists=p.if_exists_or_empty)
+    
+    # ALTER DATABASE
+    @_('ALTER DATABASE identifier kw_parameter_list')
+    def alter_database(self, p):
+        params = {k.lower(): v for k, v in p.kw_parameter_list.items()}
+        return AlterDatabase(
+            name=p.identifier,
+            altered_params=params
+        )
 
     # Transactions
 

--- a/tests/test_mindsdb/test_databases.py
+++ b/tests/test_mindsdb/test_databases.py
@@ -135,7 +135,7 @@ class TestDatabases:
         sql = "ALTER DATABASE db PARAMETERS = {'A': 1, 'B': 2}"
         ast = parse_sql(sql)
 
-        expected_ast = AlterDatabase(name=Identifier('db'), altered_params={'A': 1, 'B': 2})
+        expected_ast = AlterDatabase(name=Identifier('db'), altered_params={'parameters': {'A': 1, 'B': 2}})
 
         assert str(ast) == str(expected_ast)
         assert ast.to_tree() == expected_ast.to_tree()

--- a/tests/test_mindsdb/test_databases.py
+++ b/tests/test_mindsdb/test_databases.py
@@ -6,7 +6,7 @@ from mindsdb_sql_parser.ast.mindsdb import *
 from mindsdb_sql_parser.lexer import MindsDBLexer
 
 
-class TestCreateDatabase:
+class TestDatabases:
     def test_create_database_lexer(self):
         sql = "CREATE DATABASE IF NOT EXISTS db WITH ENGINE = 'mysql', PARAMETERS = {\"user\": \"admin\", \"password\": \"admin\"}"
         tokens = list(MindsDBLexer().tokenize(sql))
@@ -130,3 +130,12 @@ class TestCreateDatabase:
         assert str(ast).lower() == str(expected_ast).lower()
         assert ast.to_tree() == expected_ast.to_tree()
 
+
+    def test_alter_database(self):
+        sql = "ALTER DATABASE db PARAMETERS = {'A': 1, 'B': 2}"
+        ast = parse_sql(sql)
+
+        expected_ast = AlterDatabase(name=Identifier('db'), altered_params={'A': 1, 'B': 2})
+
+        assert str(ast) == str(expected_ast)
+        assert ast.to_tree() == expected_ast.to_tree()


### PR DESCRIPTION
This PR adds the syntax for `ALTER DATABASE`.

Fixes https://linear.app/mindsdb/issue/BE-1018/add-update-database-syntax-to-the-parser