### PR TITLE
Disable 'not' as binary operator

### DIFF
--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -1642,7 +1642,6 @@ class MindsDBParser(Parser):
        'expr AND expr',
        'expr OR expr',
        'expr IS_NOT expr',
-       'expr NOT expr',
        'expr IS expr',
        'expr LIKE expr',
        'expr NOT_LIKE expr',

--- a/tests/test_base_sql/test_select_operations.py
+++ b/tests/test_base_sql/test_select_operations.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mindsdb_sql_parser import parse_sql
+from mindsdb_sql_parser import parse_sql, ParsingException
 from mindsdb_sql_parser.ast import *
 
 
@@ -635,3 +635,8 @@ class TestOperationsMindsdb:
             )
 
             assert str(ast) == str(expected_ast)
+
+    def test_not(self):
+        sql = 'SELECT * from movies where genre not null'
+        with pytest.raises(ParsingException):
+            parse_sql(sql)


### PR DESCRIPTION

It is not correct query:
```sql
SELECT * from movies where genre not null
```