### PR TITLE
Fix identifier copy and deepcopy

### DIFF
--- a/mindsdb_sql_parser/ast/select/identifier.py
+++ b/mindsdb_sql_parser/ast/select/identifier.py
@@ -91,6 +91,9 @@ class Identifier(ASTNode):
         identifier = Identifier(parts=copy(self.parts))
         identifier.alias = deepcopy(self.alias)
         identifier.parentheses = self.parentheses
+        identifier.is_quoted = deepcopy(self.is_quoted)
+        identifier.is_outer = self.is_outer
+        identifier.with_rollup = self.with_rollup
         if hasattr(self, 'sub_select'):
             identifier.sub_select = deepcopy(self.sub_select)
         return identifier
@@ -99,6 +102,9 @@ class Identifier(ASTNode):
         identifier = Identifier(parts=copy(self.parts))
         identifier.alias = deepcopy(self.alias)
         identifier.parentheses = self.parentheses
+        identifier.is_quoted = deepcopy(self.is_quoted)
+        identifier.is_outer = self.is_outer
+        identifier.with_rollup = self.with_rollup
         if hasattr(self, 'sub_select'):
             identifier.sub_select = deepcopy(self.sub_select)
         return identifier

--- a/tests/test_base_sql/test_ast.py
+++ b/tests/test_base_sql/test_ast.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from mindsdb_sql_parser.ast import *
 
 
@@ -24,3 +26,8 @@ class TestAST:
         # change
         ast.where.args[0] = Constant(1)
         assert ast.to_tree() != ast2.to_tree()
+
+    def test_identifier_deepcopy_is_quoted(self):
+        ident = Identifier('`a`')
+        ident2 = deepcopy(ident)
+        assert ident2.is_quoted == [True]


### PR DESCRIPTION
Fix issue with copy identifier.is_quoted:
```
deepcopy(Identifier('`a`')).is_quoted == [False]
```