### PR TITLE
Fix query with single value in IN

### DIFF
--- a/mindsdb_sql_parser/ast/select/operation.py
+++ b/mindsdb_sql_parser/ast/select/operation.py
@@ -1,12 +1,11 @@
 from mindsdb_sql_parser.ast.base import ASTNode
 from mindsdb_sql_parser.exceptions import ParsingException
 from mindsdb_sql_parser.utils import indent
-
+from mindsdb_sql_parser.ast.select.tuple import Tuple
 
 class Operation(ASTNode):
     def __init__(self, op, args, *args_, **kwargs):
         super().__init__(*args_, **kwargs)
-        from mindsdb_sql_parser.ast import Tuple
 
         self.op = ' '.join(op.lower().split())
         self.args = []

--- a/mindsdb_sql_parser/ast/select/operation.py
+++ b/mindsdb_sql_parser/ast/select/operation.py
@@ -6,9 +6,15 @@ from mindsdb_sql_parser.utils import indent
 class Operation(ASTNode):
     def __init__(self, op, args, *args_, **kwargs):
         super().__init__(*args_, **kwargs)
+        from mindsdb_sql_parser.ast import Tuple
 
         self.op = ' '.join(op.lower().split())
-        self.args = list(args)
+        self.args = []
+        for item in args:
+            if isinstance(item, ASTNode) and item.parentheses:
+                item.parentheses = False
+                item = Tuple([item])
+            self.args.append(item)
         self.assert_arguments()
 
     def assert_arguments(self):

--- a/tests/test_base_sql/test_select_structure.py
+++ b/tests/test_base_sql/test_select_structure.py
@@ -681,6 +681,18 @@ class TestSelectStructure:
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
 
+        sql = "SELECT col FROM tab WHERE col in (1)"
+        ast = parse_sql(sql)
+        expected_ast = Select(targets=[Identifier(parts=['col'])],
+                              from_table=Identifier(parts=['tab']),
+                              where=BinaryOperation(op='in',
+                                                    args=(
+                                                        Identifier(parts=['col']),
+                                                        Tuple(items=[Constant(1)])
+                                                    )))
+        assert ast.to_tree() == expected_ast.to_tree()
+        assert str(ast) == str(expected_ast)
+
     def test_count_distinct(self):
         sql = "SELECT COUNT(DISTINCT survived) AS uniq_survived FROM titanic"
         ast = parse_sql(sql)


### PR DESCRIPTION
Before the fix this query 
```sql
select * from test_kb_crm where id in (1000)
```
is parsed the same as 
```sql
select * from test_kb_crm where id in 1000
```

The update: 
If element of operation has parentheses=False - wrap it to Tuple

Fixes https://linear.app/mindsdb/issue/UNI-149/query-id-=-555-and-id-in-555
