### PR TITLE
Alter Agent syntax

### DIFF
--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -199,6 +199,7 @@ class MindsDBParser(Parser):
         return DropAgent(name=p.identifier, if_exists=p.if_exists_or_empty)
     
     @_('UPDATE AGENT identifier SET kw_parameter_list')
+    @_('ALTER AGENT identifier USING kw_parameter_list')
     def update_agent(self, p):
         return UpdateAgent(name=p.identifier, updated_params=p.kw_parameter_list)
 

--- a/tests/test_mindsdb/test_agents.py
+++ b/tests/test_mindsdb/test_agents.py
@@ -44,6 +44,14 @@ class TestAgents:
         assert str(ast) == str(expected_ast)
         assert ast.to_tree() == expected_ast.to_tree()
 
+        sql = '''
+            alter agent my_agent
+            USING
+            model = 'new_model',
+            skills = ['new_skill1', 'new_skill2']
+        '''
+        ast = parse_sql(sql)
+
         # Parse again after rendering to catch problems with rendering.
         ast = parse_sql(str(ast))
         assert str(ast) == str(expected_ast)


### PR DESCRIPTION
Support ALTER AGENT syntax
```sql
ALTER AGENT my_agent
USING
     model = 'gemini-2.0-flash',
     api_key = 'xyz123', 
```
is alias to:
```sql
UPDATE AGENT my_agent
SET
     model = 'gemini-2.0-flash',
     api_key = 'xyz123', 
```

Fixes: https://linear.app/mindsdb/issue/RES-34/syntax-for-update-agent