### PR TITLE
Fix IN with SELECT: move 'in' logic outside of Operation class

### DIFF
--- a/mindsdb_sql_parser/__about__.py
+++ b/mindsdb_sql_parser/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql_parser'
 __package_name__ = 'mindsdb_sql_parser'
-__version__ = '0.11.0'
+__version__ = '0.11.1'
 __description__ = "Mindsdb SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql_parser/ast/select/operation.py
+++ b/mindsdb_sql_parser/ast/select/operation.py
@@ -1,19 +1,15 @@
 from mindsdb_sql_parser.ast.base import ASTNode
 from mindsdb_sql_parser.exceptions import ParsingException
 from mindsdb_sql_parser.utils import indent
-from mindsdb_sql_parser.ast.select.tuple import Tuple
+
 
 class Operation(ASTNode):
     def __init__(self, op, args, *args_, **kwargs):
         super().__init__(*args_, **kwargs)
 
         self.op = ' '.join(op.lower().split())
-        self.args = []
-        for item in args:
-            if self.op in ("in", "not in") and isinstance(item, ASTNode) and item.parentheses:
-                item.parentheses = False
-                item = Tuple([item])
-            self.args.append(item)
+        self.args = list(args)
+
         self.assert_arguments()
 
     def assert_arguments(self):

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -1673,6 +1673,12 @@ class MindsDBParser(Parser):
             arg1 = Last()
         else:
             arg1 = p[2]
+
+        op = p[1]
+        if op.lower() in ("in", "not in") and isinstance(arg1, Constant) and arg1.parentheses:
+            arg1.parentheses = False
+            arg1 = Tuple([arg1])
+
         return BinaryOperation(op=p[1], args=(p[0], arg1))
 
     @_('MINUS expr %prec UMINUS',


### PR DESCRIPTION
Fix for the query:
```sql
select * from int2.tab1
where x1 in (select id from int1.tab1)
```
The condition is made as: `BinaryOperation(Identifier('x1'), Tuple(Select(...)))`