### PR TITLE
Fix CTE with UNION

### DIFF
--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -1106,14 +1106,15 @@ class MindsDBParser(Parser):
         select.cte = p.ctes
         return select
 
-    @_('ctes COMMA identifier cte_columns_or_nothing AS LPAREN select RPAREN')
+    @_('ctes COMMA identifier cte_columns_or_nothing AS LPAREN select RPAREN',
+       'ctes COMMA identifier cte_columns_or_nothing AS LPAREN union RPAREN')
     def ctes(self, p):
         ctes = p.ctes
         ctes = ctes + [
             CommonTableExpression(
                 name=p.identifier,
                 columns=p.cte_columns_or_nothing,
-                query=p.select)
+                query=p[6])
         ]
         return ctes
 


### PR DESCRIPTION
Fix for queries with multiple CTE and UNION in it, like this one:
```sql
        WITH ta AS (
            SELECT 'a' AS a
            UNION
            SELECT 'b' AS a
        ), tb AS (
            SELECT 'c' AS a
            UNION
            SELECT 'd' AS a
        )
        SELECT a FROM ta
        UNION
        SELECT a FROM tb
```