### PR TITLE
Array operators supports

### DIFF
--- a/mindsdb_sql_parser/__about__.py
+++ b/mindsdb_sql_parser/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql_parser'
 __package_name__ = 'mindsdb_sql_parser'
-__version__ = '0.11.3'
+__version__ = '0.11.4'
 __description__ = "Mindsdb SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql_parser/lexer.py
+++ b/mindsdb_sql_parser/lexer.py
@@ -76,6 +76,7 @@ class MindsDBLexer(Lexer):
         AND, OR, NOT, IS, IS_NOT, TYPECAST,
         IN, NOT_IN, LIKE, NOT_LIKE, CONCAT, BETWEEN, WINDOW, OVER, PARTITION_BY,
         VECT_L2, VECT_L1, VECT_INNER, VECT_COS, VECT_HAMM, VECT_JACC,
+        ARR_CONTAINS, ARR_CONTAINED, ARR_OVERLAP,
         JSON_GET, JSON_GET_STR, INTERVAL,
 
         # Data types
@@ -290,6 +291,10 @@ class MindsDBLexer(Lexer):
     VECT_COS = r'<=>'
     VECT_HAMM = r'<~>'
     VECT_JACC = r'<%>'
+
+    ARR_CONTAINS = r'@>'
+    ARR_CONTAINED = r'<@'
+    ARR_OVERLAP = r'&&'
 
     JSON_GET_STR = r'->>'
     JSON_GET = r'->'

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -1664,6 +1664,9 @@ class MindsDBParser(Parser):
        'expr JSON_GET constant',
        'expr JSON_GET_STR constant',
        'expr NOT_IN expr',
+       'expr ARR_CONTAINS expr',
+       'expr ARR_CONTAINED expr',
+       'expr ARR_OVERLAP expr',
        'expr IN expr',)
     def expr(self, p):
         if p[1] == ':=':

--- a/tests/test_mindsdb/test_selects.py
+++ b/tests/test_mindsdb/test_selects.py
@@ -225,3 +225,22 @@ class TestSpecificSelects:
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
 
+    def test_array(self):
+        for op in ['@>', '<@', '&&']:
+            sql = f"SELECT * from TAB1 WHERE a {op} b"
+
+            ast = parse_sql(sql)
+            expected_ast = Select(
+                targets=[Star()],
+                where=BinaryOperation(
+                    op=op,
+                    args=[
+                        Identifier('a'),
+                        Identifier('b')
+                    ]
+                ),
+                from_table=Identifier(parts=['TAB1']),
+            )
+
+            assert ast.to_tree() == expected_ast.to_tree()
+            assert str(ast) == str(expected_ast)


### PR DESCRIPTION
Added support of array operators:
- `@>` contains
- `<@` is contained by
- `&&` overlap


https://postgrespro.ru/docs/postgrespro/9.5/functions-array

Fixes https://linear.app/mindsdb/issue/CONN-1415/sema4-support-in-parser