### PR TITLE
Fix `CreateTable` dump to string

### DIFF
--- a/mindsdb_sql_parser/ast/create.py
+++ b/mindsdb_sql_parser/ast/create.py
@@ -95,6 +95,8 @@ class CreateTable(ASTNode):
                         type = 'float'
                     elif issubclass(col.type, sa_types.Text):
                         type = 'text'
+                    elif hasattr(col.type, '__visit_name__'):
+                        type = col.type.__visit_name__
                 else:
                     type = str(col.type)
                 if col.length is not None:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,2 @@
 pytest>=5.4.3
+sqlalchemy >= 2.0.0, < 3.0.0

--- a/tests/test_base_sql/test_create.py
+++ b/tests/test_base_sql/test_create.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy import types as sa_types
 
 from mindsdb_sql_parser import parse_sql
 from mindsdb_sql_parser.ast import *
@@ -178,3 +179,16 @@ class TestCreateMindsdb:
         assert str(ast).lower() == str(expected_ast).lower()
         assert ast.to_tree() == expected_ast.to_tree()
 
+        # test dump of sqlalchemy types
+        create_table_ast = CreateTable(
+            name=Identifier('mydb.Persons'),
+            columns=[
+                TableColumn(name='PersonID', type=sa_types.Integer),
+                TableColumn(name='LastName', type=sa_types.Text),
+                TableColumn(name='CreatedAt', type=sa_types.Date),
+            ]
+        )
+
+        expected_sql = "CREATE TABLE mydb.Persons (PersonID int, LastName text, CreatedAt date)"
+
+        assert ' '.join(create_table_ast.to_string().split()) == expected_sql


### PR DESCRIPTION
If CreateTable contains columns with sqlalchemy types, then it may fail when dump to string.

```sql
from sqlalchemy.types import Date
from mindsdb_sql_parser.ast import *

ast = CreateTable(name='test', columns=[TableColumn(name='test', type=Date)], is_replace=True)
ast.to_string()
```