### PR TITLE
Save is_quoted info for double quoted identifier

### DIFF
--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -1885,6 +1885,8 @@ class MindsDBParser(Parser):
     @_('id', 'dquote_string')
     def identifier(self, p):
         value = p[0]
+        if hasattr(p, 'dquote_string'):
+            return Identifier(parts=[value], is_quoted=[True])
         return Identifier(value)
 
     @_('PARAMETER')

--- a/tests/test_base_sql/test_base_sql.py
+++ b/tests/test_base_sql/test_base_sql.py
@@ -86,3 +86,17 @@ b"
 
         assert str(ast).lower() == str(expected_ast).lower()
         assert ast.to_tree() == expected_ast.to_tree()
+
+    def test_double_quoted_identifier(self):
+        sql = 'select * from "table.name"'
+
+        expected_ast = Select(
+            targets=[
+                Star()
+            ],
+            from_table=Identifier(parts=['table.name'], is_quoted=[True])
+        )
+        ast = parse_sql(sql)
+
+        assert str(ast).lower() == str(expected_ast).lower()
+        assert ast.to_tree() == expected_ast.to_tree()


### PR DESCRIPTION
This query should be parsed as quoted and have only one part

```sql
select * from "table.name"
```