### PR TITLE
Exception message for multiple statements in single query

### DIFF
--- a/mindsdb_sql_parser/__about__.py
+++ b/mindsdb_sql_parser/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql_parser'
 __package_name__ = 'mindsdb_sql_parser'
-__version__ = '0.13.7'
+__version__ = '0.13.8'
 __description__ = "Mindsdb SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql_parser/__init__.py
+++ b/mindsdb_sql_parser/__init__.py
@@ -25,6 +25,11 @@ class ErrorHandling:
         # show error location
         msgs = self.error_location()
 
+        if self.bad_token is not None and self.bad_token.value == ';':
+            # unexpected semicolon in the middle of the query, it might be delimiter of statements
+            msgs.append('Only a single sql statement is expected. Got multiple instead')
+            return '\n'.join(msgs)
+
         # suggestion
         suggestions = self.make_suggestion()
 
@@ -170,6 +175,10 @@ def parse_sql(sql, dialect=None):
     from mindsdb_sql_parser.lexer import MindsDBLexer
     from mindsdb_sql_parser.parser import MindsDBParser
     lexer, parser = MindsDBLexer(), MindsDBParser()
+
+    # remove comments
+    sql = re.sub(r'--.*?$', '', sql, flags=re.MULTILINE)
+    sql = re.sub(r'/\*.*?\*/', '', sql, flags=re.DOTALL)
 
     # remove ending semicolon and spaces
     sql = re.sub(r'[\s;]+$', '', sql)

--- a/mindsdb_sql_parser/parser.py
+++ b/mindsdb_sql_parser/parser.py
@@ -43,6 +43,7 @@ Unfortunately the rules are not iherited from base SQLParser, because it just do
 class MindsDBParser(Parser):
     log = ParserLogger()
     tokens = MindsDBLexer.tokens
+    start = "query"
 
     precedence = (
         ('left', OR),

--- a/tests/test_base_sql/test_base_sql.py
+++ b/tests/test_base_sql/test_base_sql.py
@@ -110,4 +110,22 @@ b"
         query = parse_sql(sql)
         assert query == Select(targets=[Constant(1)])
 
+    def test_comment_symbols_in_string(self):
+        expected_query = Select(targets=[Constant('--x')])
+
+        query = parse_sql("select '--x'")
+        assert query == expected_query
+
+        query = parse_sql('select "--x"')
+        assert query == expected_query
+
+        # multiline
+        expected_query = Select(targets=[Constant('/*  x */')])
+
+        query = parse_sql("select '/*  x */'")
+        assert query == expected_query
+
+        query = parse_sql('select "/*  x */"')
+        assert query == expected_query
+
 

--- a/tests/test_base_sql/test_base_sql.py
+++ b/tests/test_base_sql/test_base_sql.py
@@ -102,6 +102,10 @@ b"
 
         assert "Only a single sql statement is expected" in str(excinfo.value)
 
+    def test_trailing_semicolon(self):
+        query = parse_sql("select 1;")
+        assert query == Select(targets=[Constant(1)])
+
     def test_comment_after_semicolon(self):
         sql = """
         select 1; -- my query
@@ -127,5 +131,4 @@ b"
 
         query = parse_sql('select "/*  x */"')
         assert query == expected_query
-
 

--- a/tests/test_base_sql/test_base_sql.py
+++ b/tests/test_base_sql/test_base_sql.py
@@ -1,5 +1,9 @@
 from textwrap import dedent
+
+import pytest
+
 from mindsdb_sql_parser import parse_sql
+from mindsdb_sql_parser.exceptions import ParsingException
 
 from mindsdb_sql_parser.ast import *
 
@@ -86,3 +90,24 @@ b"
 
         assert str(ast).lower() == str(expected_ast).lower()
         assert ast.to_tree() == expected_ast.to_tree()
+
+    def test_multy_statement(self):
+        sql = """
+        select 1; 
+        select 2
+        """
+
+        with pytest.raises(ParsingException) as excinfo:
+            parse_sql(sql)
+
+        assert "Only a single sql statement is expected" in str(excinfo.value)
+
+    def test_comment_after_semicolon(self):
+        sql = """
+        select 1; -- my query
+        """
+
+        query = parse_sql(sql)
+        assert query == Select(targets=[Constant(1)])
+
+


### PR DESCRIPTION
If string contain several statement it returns message about it:
```sql
-- Step 1: Identify all customers in the 'BUILDING' segment
SELECT c_custkey, c_name FROM tpch_pg_conn.customer WHERE c_mktsegment = 'BUILDING';
-- Step 2: Link these customers to their orders
-- (Checking if any supplier or part reference exists in orders table)
SELECT * FROM tpch_pg_conn.orders LIMIT 5;
```
response will be
```
>  SELECT c_custkey, c_name FROM tpch_pg_conn.customer WHERE c_mktsegment = 'BUILDING';
--------------------------------------------------------------------------------------^
Only a single sql statement is expected. Got multiple instead
```

Also queries with leading comments used to raise before, fixed in this PR
```sql
select 1; -- my query
```

Fixes: https://linear.app/mindsdb/issue/FQE-2076/agents-agent-streaming-failed-problem-with-final-query-syntax-error